### PR TITLE
Update the init_database function

### DIFF
--- a/app.py
+++ b/app.py
@@ -93,7 +93,7 @@ def summary():
 def product():
     init_database()
     msg = None
-    db = sqlite3.connect(DATABASE_NAME)
+    db = sqlite3.connect(app.config["DATABASE"])
     cursor = db.cursor()
 
     cursor.execute("SELECT * FROM products")

--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ link["index"] = '/'
 
 
 def init_database():
-    db = sqlite3.connect(DATABASE_NAME)
+    db = sqlite3.connect(app.config["DATABASE"])
     cursor = db.cursor()
 
     # initialize page content


### PR DESCRIPTION
The DATABASE_NAME constant is used in the init_database function, but it is not passed as an argument to the sqlite3.connect() function. Instead, it should be passed as an argument to connect to the correct database. 